### PR TITLE
ODP-4409 Backport missing commits from Impala 4.4.1 to ODP-main

### DIFF
--- a/bin/impala-config.sh
+++ b/bin/impala-config.sh
@@ -70,7 +70,7 @@ fi
 # WARNING: If changing this value, also run these commands:
 # cd ${IMPALA_HOME}/java
 # mvn versions:set -DnewVersion=YOUR_NEW_VERSION
-export IMPALA_VERSION=4.4.0.3.3.6.1.1
+export IMPALA_VERSION=4.4.1.3.3.6.1-SNAPSHOT
 
 # Whether to build on Apache Hive (or CDP Hive). Versions of some toolchain dependencies
 # (e.g. thrift) will also depend on this.

--- a/common/thrift/Query.thrift
+++ b/common/thrift/Query.thrift
@@ -238,8 +238,10 @@ struct TQueryOptions {
   // be rounded up to the nearest power of two.
   38: optional i32 runtime_bloom_filter_size = 1048576
 
-  // Time in ms to wait until runtime filters are delivered. If 0, the default defined
-  // by the startup flag of the same name is used.
+  // Time in ms to wait until runtime filters are delivered. Note that the wait time for
+  // a runtime filter is with respect to the start of processing the query in the given
+  // executor instead of the beginning of the Open phase of a scan node. If 0, the
+  // default defined by the startup flag of the same name is used.
   39: optional i32 runtime_filter_wait_time_ms = 0
 
   // If true, per-row runtime filtering is disabled

--- a/docs/impala.ditamap
+++ b/docs/impala.ditamap
@@ -237,6 +237,7 @@ under the License.
         <topicref href="topics/impala_request_pool.xml"/>
         <topicref href="topics/impala_resource_trace_ratio.xml"/>
         <topicref rev="4.0.0" href="topics/impala_retry_failed_queries.xml"/>
+        <topicref rev="4.0.0" href="topics/impala_enabled_runtime_filter_types.xml"/>
         <topicref rev="2.5.0" href="topics/impala_runtime_bloom_filter_size.xml"/>
         <topicref rev="2.6.0" href="topics/impala_runtime_filter_max_size.xml"/>
         <topicref rev="2.6.0" href="topics/impala_runtime_filter_min_size.xml"/>

--- a/docs/impala.ditamap
+++ b/docs/impala.ditamap
@@ -108,7 +108,10 @@ under the License.
       </topicref>
       <topicref href="topics/impala_tinyint.xml"/>
       <topicref href="topics/impala_varchar.xml"/>
-      <topicref href="topics/impala_complex_types.xml"/>
+      <topicref href="topics/impala_complex_types.xml">
+        <topicref href="topics/impala_queryingarrays.xml"/>
+        <topicref href="topics/impala_unnest_views.xml"/>
+      </topicref>
     </topicref>
     <topicref href="topics/impala_literals.xml"/>
     <topicref href="topics/impala_operators.xml"/>

--- a/docs/shared/ImpalaVariables.xml
+++ b/docs/shared/ImpalaVariables.xml
@@ -42,6 +42,7 @@ under the License.
        The docs included with a distro can refer to the distro release number by
        editing the values here.
        <ul>
+        <li><ph id="impala40">Impala 4.0</ph></li>
         <li><ph id="impala34">Impala 3.4</ph></li>
         <li><ph id="impala33">Impala 3.3</ph></li>
         <li><ph id="impala32">Impala 3.2</ph></li>

--- a/docs/shared/impala_common.xml
+++ b/docs/shared/impala_common.xml
@@ -1524,7 +1524,20 @@ alter table partitioned_data set tblproperties ('numRows'='1030000', 'STATS_GENE
         <xref href="https://asciinema.org/a/1rv7qippo0fe7h5k1b6k4nexk" scope="external" format="html">this
           animated demo</xref>.
       </p>
-      
+
+      <p id="comma_separated_values_blurb">
+        Impala backend expects comma separated values to be in quotes when executing the
+        <codeph>SET</codeph> statement.
+        This is usually the case when running SET statement like
+        <codeph>SET ENABLED_RUNTIME_FILTER_TYPES="value1,value2"</codeph> using a JDBC
+        driver. When using Impala-shell client, the <codeph>SET</codeph> statement is not
+        executed immediately but query options are updated in the client and applied as
+        part of the following statement, so no quotes are required for Impala-shell. That
+        is, we use SET statement like
+        <codeph>SET ENABLED_RUNTIME_FILTER_TYPES=value1,value2</codeph> when
+        submitting the query to Impala backend via Impala-shell client.
+      </p>
+
       <p rev="2.5.0" id="runtime_filter_mode_blurb">
         Because the runtime filtering feature is
         enabled by default only for local processing, the other filtering-related query options have
@@ -3417,6 +3430,10 @@ flight_num:           INT32 SNAPPY DO:83456393 FPO:83488603 SZ:10216514/11474301
       <p id="internals_min_bytes">
         <b>Internal details:</b> Represented in memory as a byte array with the minimum size
         needed to represent each value.
+      </p>
+
+      <p rev="4.0.0" id="added_in_400">
+        <b>Added in:</b> <keyword keyref="impala40"/>
       </p>
 
       <p rev="3.0" id="added_in_30">

--- a/docs/topics/impala_authorization.xml
+++ b/docs/topics/impala_authorization.xml
@@ -255,14 +255,11 @@ under the License.
 
       <conbody>
 
-        <p>
-          URIs represent the file paths you specify as part of statements such as <codeph>CREATE
-          EXTERNAL TABLE</codeph> and <codeph>LOAD DATA</codeph>. Typically, you specify what
-          look like UNIX paths, but these locations can also be prefixed with
-          <codeph>hdfs://</codeph> to make clear that they are really URIs. To set privileges
-          for a URI, specify the name of a directory, and the privilege applies to all the files
-          in that directory and any directories underneath it.
-        </p>
+        <p> URIs represent the file paths you specify as part of statements such as <codeph>CREATE
+            EXTERNAL TABLE</codeph> and <codeph>LOAD DATA</codeph>. Typically, you specify what look
+          like UNIX paths, but these locations can also be prefixed with <codeph>hdfs://</codeph> to
+          make clear that they are really URIs. To set privileges for a URI, specify the name of a
+          directory, and the privilege applies to all the files in that directory. </p>
 
         <p>
           URIs must start with <codeph>hdfs://</codeph>, <codeph>s3a://</codeph>,

--- a/docs/topics/impala_complex_types.xml
+++ b/docs/topics/impala_complex_types.xml
@@ -45,8 +45,6 @@ under the License.
       and higher. The Hive <codeph>UNION</codeph> type is not currently supported.
     </p>
 
-    <p outputclass="toc inpage"/>
-
     <p>
       Once you understand the basics of complex types, refer to the individual type topics when you need to refresh your memory about syntax
       and examples:
@@ -65,6 +63,9 @@ under the License.
         <xref href="impala_map.xml#map"/>
       </li>
     </ul>
+    <p outputclass="toc inpage"/>
+    <p>For information on querying arrays and improvements to zipping unnest functionality, refer to
+      the following:</p>
 
   </conbody>
 

--- a/docs/topics/impala_components.xml
+++ b/docs/topics/impala_components.xml
@@ -141,20 +141,25 @@ under the License.
 
     <conbody>
 
-      <p> The Impala component known as the Catalog Service relays the metadata
-        changes from Impala SQL statements to all the Impala daemons in a
-        cluster. It is physically represented by a daemon process named
-          <codeph>catalogd</codeph>. You only need such a process on one host in
-        a cluster. Because the requests are passed through the StateStore
-        daemon, it makes sense to run the <cmdname>statestored</cmdname> and
-          <cmdname>catalogd</cmdname> services on the same host. </p>
+      <p> The Impala component known as the Catalog Service relays the metadata changes from Impala
+        SQL statements to all the Impala coordinators in a cluster. It is physically represented by
+        a daemon process named <codeph>catalogd</codeph>. You only need such a process on one host
+        in a cluster. Because the requests are passed through the StateStore daemon, it makes sense
+        to run the <cmdname>statestored</cmdname> and <cmdname>catalogd</cmdname> services on the
+        same host. </p>
 
-      <p> The catalog service avoids the need to issue <codeph>REFRESH</codeph>
-        and <codeph>INVALIDATE METADATA</codeph> statements when the metadata
-        changes are performed by statements issued through Impala. When you
-        create a table, load data, and so on through Hive, you do need to issue
-          <codeph>REFRESH</codeph> or <codeph>INVALIDATE METADATA</codeph> on an
-        Impala daemon before executing a query there. </p>
+      <p> The catalog service avoids the need to issue <codeph>REFRESH</codeph> and
+          <codeph>INVALIDATE METADATA</codeph> statements when the metadata changes are performed by
+        statements issued through Impala.
+      </p> 
+      <p> When you create a table, load data, and so on through Hive, you do need to issue
+          <codeph>REFRESH</codeph> or <codeph>INVALIDATE METADATA</codeph> on an Impala daemon
+        before executing a query. Performing <codeph>REFRESH</codeph> or <codeph>INVALIDATE
+          METADATA</codeph> is not required when <cite>Automatic Invalidation/Refresh of
+          Metadata</cite> is enabled. See <xref href="impala_metadata.xml#impala_metadata">Automatic
+          Invalidation/Refresh of Metadata</xref> also known as the Hive Metastore (HMS) event
+          processor.<note id="note_eyx_qcp_fcc" type="note">From Impala 4.1, Automatic
+          Invalidation/Refresh of Metadata is enabled by default.</note></p>
 
       <p>
         This feature touches a number of aspects of Impala:

--- a/docs/topics/impala_enabled_runtime_filter_types.xml
+++ b/docs/topics/impala_enabled_runtime_filter_types.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
+<concept id="enabled_runtime_filter_types" rev="4.0.0">
+
+  <title>ENABLED_RUNTIME_FILTER_TYPES Query Option (<keyword keyref="impala40"/> or higher only)</title>
+  <titlealts audience="PDF"><navtitle>ENABLED RUNTIME FILTER TYPES</navtitle></titlealts>
+  <prolog>
+    <metadata>
+      <data name="Category" value="Impala"/>
+      <data name="Category" value="Impala Query Options"/>
+      <data name="Category" value="Performance"/>
+      <data name="Category" value="Developers"/>
+      <data name="Category" value="Data Analysts"/>
+    </metadata>
+  </prolog>
+
+  <conbody>
+
+    <p rev="4.0.0">
+      <indexterm audience="hidden">ENABLED_RUNTIME_FILTER_TYPES query option</indexterm>
+      The <codeph>ENABLED_RUNTIME_FILTER_TYPES</codeph> query option
+      sets enabled runtime filter types to be applied to scanners.
+      This option only applies to HDFS scan nodes and Kudu scan nodes.
+      The following types are supported.
+      Specify the enabled types by a comma-separated list of the following values
+      or enable all types by "<codeph>ALL</codeph>".
+      <ul>
+        <li>
+          <codeph>BLOOM</codeph>
+        </li>
+        <li>
+          <codeph>MIN_MAX</codeph>
+        </li>
+        <li>
+          <codeph>IN_LIST</codeph>
+        </li>
+      </ul>
+    </p>
+
+    <p>
+      <b>Default:</b> <codeph>"BLOOM,MIN_MAX"</codeph>
+    </p>
+    <p conref="../shared/impala_common.xml#common/type_string"/>
+
+    <p conref="../shared/impala_common.xml#common/added_in_400"/>
+
+    <p conref="../shared/impala_common.xml#common/usage_notes_blurb"/>
+
+    <p conref="../shared/impala_common.xml#common/comma_separated_values_blurb"/>
+
+    <p>
+      Depending on the scan node type, Planner can schedule compatible runtime filter
+      types as follows.
+      <ul>
+        <li>Kudu scan: <codeph>BLOOM</codeph>, <codeph>MIN_MAX</codeph></li>
+        <li>
+          HDFS scan on Parquet files: <codeph>BLOOM</codeph>, <codeph>MIN_MAX</codeph>
+        </li>
+        <li>HDFS scan on ORC files: <codeph>BLOOM</codeph>, <codeph>IN_LIST</codeph></li>
+        <li>HDFS scan on other kinds of files: <codeph>BLOOM</codeph></li>
+      </ul>
+    </p>
+
+    <p conref="../shared/impala_common.xml#common/related_info"/>
+    <p>
+      <xref href="impala_runtime_filtering.xml"/>,
+      <xref href="impala_runtime_filter_mode.xml#runtime_filter_mode"/>
+    </p>
+
+  </conbody>
+</concept>

--- a/docs/topics/impala_queryingarrays.xml
+++ b/docs/topics/impala_queryingarrays.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
+<concept id="impala_queryingarrays" rev="4.1.0">
+  <title>Querying arrays (<keyword keyref="impala41"/> or higher only)</title>
+  <titlealts audience="PDF">
+    <navtitle>Querying arrays</navtitle>
+  </titlealts>
+  <prolog>
+    <metadata>
+      <data name="Category" value="Impala"/>
+      <data name="Category" value="Impala Data Types"/>
+      <data name="Category" value="SQL"/>
+      <data name="Category" value="Data Analysts"/>
+      <data name="Category" value="Developers"/>
+      <data name="Category" value="Schemas"/>
+    </metadata>
+  </prolog>
+  <conbody>
+    <p rev="4.1.0">
+      <indexterm audience="hidden">Querying arrays</indexterm> Describes how to use UNNEST function
+      to query arrays. ARRAY data types represent collections with arbitrary numbers of elements,
+      where each element is the same type.</p>
+    <section id="section_yl4_2qb_3cc">
+      <title>Querying arrays using JOIN and UNNEST</title>
+      <p>You can query arrays by making a join between the table and the array inside the table.
+        This approach is improved with the introduction of the <codeph>UNNEST</codeph> function in
+        the <codeph>SELECT</codeph> list or in the <codeph>FROM</codeph> clause in the
+          <codeph>SELECT</codeph> statement. When you use <codeph>UNNEST</codeph>, you can provide
+        more than one array in the <codeph>SELECT</codeph> statement. If you use JOINs for querying
+        arrays it will yield a <term>joining unnest</term> however the latter will provide a
+          <term>zipping unnest</term>.</p>
+    </section>
+    <section id="section_hmf_hqb_3cc">
+      <title>Example of querying arrays using JOIN</title>
+      <p>Use <codeph>JOIN</codeph> in cases where you must join unnest of multiple arrays. However
+        if you must zip unnest then use the newly implemented <codeph>UNNEST</codeph> function.</p>
+      <p>Here is an example of a <codeph>SELECT</codeph> statement that uses JOINs to query an
+        array.</p>
+      <codeblock id="codeblock_uqy_rqb_3cc">SELECT id, arr1.item, arr2.item FROM tbl_name tbl, tbl.arr1, tbl.arr2;
+
+ID, ARR1.ITEM, ARR2.ITEM
+[1, 1, 10]
+[1, 1, 11]
+[1, 2, 10]
+[1, 2, 11]
+[1, 3, 10]
+[1, 3, 11]
+</codeblock>
+      <note id="note_tpb_wln_htb">
+        <p>The test data used in this example is ID: 1, arr1: {1, 2, 3}, arr2: {10, 11}</p>
+      </note>
+    </section>
+    <section id="section_ipq_tqb_3cc">
+      <title>Examples of querying arrays using UNNEST</title>
+      <p>You can use one of the two different syntaxes shown here to unnest multiple arrays in one
+        query. This results in the items of the arrays being zipped together instead of joining.</p>
+      <ul id="ul_jpq_tqb_3cc">
+        <li>ISO:SQL 2016 compliant syntax:
+          <codeblock id="codeblock_kpq_tqb_3cc">SELECT a1.item, a2.item
+FROM complextypes_arrays t, UNNEST(t.arr1, t.arr2) AS (a1, a2);
+</codeblock></li>
+        <li>Postgres compatible
+          syntax:<codeblock id="codeblock_yl5_3mn_htb">SELECT UNNEST(arr1), UNNEST(arr2) FROM complextypes_arrays;</codeblock></li>
+      </ul>
+      <p><b>Unnest operator in SELECT list</b></p>
+      <codeblock id="codeblock_lpq_tqb_3cc">SELECT id, unnest(arr1), unnest(arr2) FROM tbl_name;</codeblock>
+      <p><b>Unnest operator in FROM clause</b></p>
+      <codeblock id="codeblock_mpq_tqb_3cc">SELECT id, arr1.item, arr2.item FROM tbl_name tbl_alias, UNNEST(tbl_alias.arr1, tbl_alias.arr2);</codeblock>
+      <p>This new functionality would zip the arrays next to each other as shown here. </p>
+      <codeblock id="codeblock_npq_tqb_3cc">ID, ARR1.ITEM, ARR2.ITEM
+[1, 1, 10]
+[1, 2, 11]
+[1, 3, NULL]
+</codeblock>
+      <p>Note, that arr2 is shorter than arr1 so the "missing" items in its column will be filled
+        with NULLs.</p>
+      <note id="note_opq_tqb_3cc">The test data used in this example is ID: 1, arr1: {1, 2, 3},
+        arr2: {10, 11}</note>
+    </section>
+    <section id="section_i1g_wqb_3cc">
+      <title>Limitations in Using UNNEST</title>
+      <p>
+        <ul id="ul_j1g_wqb_3cc">
+          <li>Only arrays from the same table can be zipping unnested</li>
+          <li>The old (joining) and the new (zipping) unnests cannot be used together</li>
+          <li>You can add a <codeph>WHERE</codeph> filter on an unnested item only if you add a
+            wrapper <codeph>SELECT</codeph> and do the filtering
+            <p>Example:</p><codeblock id="codeblock_k1g_wqb_3cc">SELECT id, arr1_unnest FROM (SELECT id, unnest(arr1) as arr1_unnest FROM tbl_name) WHERE arr1_unnest &lt; 10;</codeblock></li>
+        </ul>
+      </p>
+    </section>
+    <section id="section_ewb_yqb_3cc">
+      <title>Using ARRAY columns in the SELECT list</title>
+      <!--Removing this since zipping unnest for arrays (IMPALA-10920) and allow array type in SELECT list (IMPALA-9498) are all added in the same upstream release (Impala 4.1)
+      <p>Prior to this release to look into the content of an array you had to unnest the array
+        either by the joining syntax or by using the zipping <codeph>UNNEST</codeph> operator as
+        shown in the following example:</p>
+      <codeblock id="codeblock_fwb_yqb_3cc">SELECT unnest(IDs), unnest(NAMES) FROM table_name;</codeblock>
+      -->
+      <p rev="4.1">Impala 4.1 adds support to return <codeph>ARRAYs</codeph> as
+          <codeph>STRINGs</codeph> (<term>JSON arrays</term>) in the <codeph>SELECT</codeph> list,
+        for example: </p>
+      <codeblock id="codeblock_gwb_yqb_3cc">select id, int_array from functional_parquet.complextypestbl where id = 1;
+returns: 1, “[1,2,3]”
+</codeblock>
+      <p>Returning <codeph>ARRAYs</codeph> from inline or Hive Metastore views is also supported.
+        These arrays can be used both in the select list or as relative table references.</p>
+      <codeblock id="codeblock_hwb_yqb_3cc">select id, int_array from (select id, int_array from complextypestbl) s;</codeblock>
+      <p>Though <codeph>STRUCTs</codeph> are already supported, <codeph>ARRAYs</codeph> and
+          <codeph>STRUCTs</codeph> nested within each other are not supported yet. Using them as
+        non-relative table references is also not supported yet.</p>
+    </section>
+  </conbody>
+</concept>

--- a/docs/topics/impala_runtime_filter_wait_time_ms.xml
+++ b/docs/topics/impala_runtime_filter_wait_time_ms.xml
@@ -40,6 +40,13 @@ under the License.
       adjusts the settings for the runtime filtering feature.
       It specifies a time in milliseconds that each scan node waits for
       runtime filters to be produced by other plan fragments.
+      Note that the wait time for a runtime filter is with respect to the start of
+      processing the query in the given executor instead of the beginning of the Open
+      phase of a scan node. For instance, a scan node could start so late that at the
+      beginning of the Open phase of the scan node, the amount of time passed since the
+      start of query processing was already greater than the value of
+      <codeph>RUNTIME_FILTER_WAIT_TIME_MS</codeph>. In such a case, even though the
+      runtime filter has not arrived yet, the scan node will not wait any longer.
     </p>
 
     <p conref="../shared/impala_common.xml#common/type_integer"/>

--- a/docs/topics/impala_runtime_filtering.xml
+++ b/docs/topics/impala_runtime_filtering.xml
@@ -242,12 +242,12 @@ under the License.
         <codeph>RUNTIME_FILTER_WAIT_TIME_MS</codeph> query option.
       </p>
       <p>
-        By default, each scan node waits for up to 1 second (1000 milliseconds)
-        for filters to arrive. If all filters have not arrived within the
-        specified interval, the scan node proceeds, using whatever filters
-        did arrive to help avoid reading unnecessary data. If a filter arrives
-        after the scan node begins reading data, the scan node applies that
-        filter to the data that is read after the filter arrives, but not to
+        The time is counted from the start of executing the query — see the query
+        option's doc page for details.
+        If all filters have not arrived within the specified interval, the scan node
+        proceeds, using whatever filters did arrive to help avoid reading unnecessary
+        data. If a filter arrives after the scan node begins reading data, the scan node
+        applies that filter to the data that is read after the filter arrives, but not to
         the data that was already read.
       </p>
       <p>

--- a/docs/topics/impala_unnest_views.xml
+++ b/docs/topics/impala_unnest_views.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<!DOCTYPE concept PUBLIC "-//OASIS//DTD DITA Concept//EN" "concept.dtd">
+<concept id="impala_unnest_views" rev="4.1.0">
+  <title>Zipping unnest on arrays from views (<keyword keyref="impala41"/> or higher only)</title>
+  <titlealts audience="PDF">
+    <navtitle>Zipping unnest on arrays from views</navtitle>
+  </titlealts>
+  <prolog>
+    <metadata>
+      <data name="Category" value="Impala"/>
+      <data name="Category" value="Impala Data Types"/>
+      <data name="Category" value="SQL"/>
+      <data name="Category" value="Data Analysts"/>
+      <data name="Category" value="Developers"/>
+      <data name="Category" value="Schemas"/>
+    </metadata>
+  </prolog>
+  <conbody>
+    <p rev="4.1.0">
+      <indexterm audience="hidden">Zipping unnest on arrays from views</indexterm>
+      <keyword keyref="impala41"/>, the zipping unnest functionality works for arrays in both tables
+      and
+      views.<codeblock id="codeblock_nwz_lyc_3cc">SELECT UNNSET(arr1) FROM view_name;</codeblock>
+    </p>
+    <section id="section_irf_rrb_3cc">
+      <title>UNNEST() on array columns</title>
+      <p>You can use <codeph>UNNEST()</codeph> on array columns in two ways. Using one of these two
+        ways results in the items of the arrays being zipped together instead of joining.</p>
+      <ul id="ul_jrf_rrb_3cc">
+        <li>ISO:SQL 2016 compliant syntax</li>
+      </ul>
+      <codeblock id="codeblock_krf_rrb_3cc">SELECT a1.item, a2.item
+FROM complextypes_arrays t, UNNEST(t.arr1, t.arr2) AS (a1, a2);
+</codeblock>
+      <ul id="ul_lrf_rrb_3cc">
+        <li>Postgres compatible syntax</li>
+      </ul>
+      <codeblock id="codeblock_mrf_rrb_3cc">SELECT UNNEST(arr1), UNNEST(arr2) FROM complextypes_arrays;</codeblock>
+      <p>When unnesting multiple arrays with zipping unnest, the i'th item of one array will be
+        placed next to the i'th item of the other arrays in the results. If the size of the arrays
+        is not equal then the shorter arrays will be filled with NULL values up to the size of the
+        longest array as shown in the following example:</p>
+      <p>The test data used in this example is arr1: {1, 2, 3}, arr2: {11, 12}</p>
+      <p>After running any of the queries listed in the examples, the result will be as shown
+        here:</p>
+      <p>
+        <codeblock id="codeblock_n5z_cjq_mtb">arr1 arr2
+[1, 11]
+[2, 12]
+[3, NULL]
+</codeblock>
+      </p>
+    </section>
+    <section id="section_ifc_trb_3cc">
+      <title>Example of an UNNEST() in an inline view using SELECT/FILTER of the inline view</title>
+      <p>In the following example the filter is not in the <codeph>SELECT</codeph> query that
+        creates the inline view but a level above that.</p>
+      <codeblock id="codeblock_jfc_trb_3cc">SELECT id, ac1, ac2 FROM (SELECT id, UNNEST(array_col1) AS ac1, UNNEST(array_col2) AS ac2 FROM some_view) WHERE id &lt;10;
+</codeblock>
+    </section>
+  </conbody>
+</concept>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -948,6 +948,98 @@ under the License.
           <skip>${jacoco.skip}</skip>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>enforce-banned-dependencies</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <bannedDependencies>
+                  <excludes>
+                    <!-- We shouldn't have a runtime dependency on Ant or the
+                         Jetty server -->
+                    <exclude>ant:*</exclude>
+                    <exclude>ant-contrib:*</exclude>
+                    <exclude>org.apache.ant:*</exclude>
+                    <exclude>org.eclipse.jetty:*</exclude>
+                    <!-- We use reload4j, exclude log4j 1.x and 2.x -->
+                    <exclude>org.apache.logging.log4j:log4j-slf4j-impl</exclude>
+                    <exclude>org.apache.logging.log4j:log4j-1.2-api</exclude>
+                    <exclude>log4j:*</exclude>
+                    <exclude>org.slf4j:slf4j-log4j12</exclude>
+                    <!-- IMPALA-9108: Avoid pulling in leveldbjni, which is unneeded. -->
+                    <exclude>org.fusesource.leveldbjni:*</exclude>
+                    <!-- IMPALA-9647 (re: CVE-2014-3577, CVE-2015-5262) -->
+                    <exclude>org.apache.httpcomponents:fluent-hc</exclude>
+                    <!-- IMPALA-9649 (Avoid pulling in shiro* due to CVE's) -->
+                    <exclude>org.apache.shiro:shiro-core:*</exclude>
+                    <exclude>org.apache.shiro:shiro-crypto-cipher:*</exclude>
+                    <!-- Avoid runtime dependency on rocksdb. -->
+                    <exclude>org.rocksdb:*</exclude>
+                    <!-- Avoid runtime dependency on Jersey server components. -->
+                    <exclude>com.sun.jersey:jersey-server</exclude>
+                    <exclude>com.sun.jersey:jersey-server</exclude>
+                    <exclude>org.glassfish.jersey.core:jersey-servlet</exclude>
+                    <exclude>org.glassfish.jersey.core:jersey-servlet</exclude>
+                    <!-- IMPALA-9708: Sentry is removed. -->
+                    <exclude>org.apache.sentry:*</exclude>
+                    <!-- IMPALA-11673: Ensure spring-jcl is not present. -->
+                    <exclude>org.springframework:spring-jcl</exclude>
+                    <!-- Assert that we only use artifacts from only the specified
+                         version of these components. -->
+                    <exclude>org.apache.hadoop:*</exclude>
+                    <exclude>org.apache.hbase:*</exclude>
+                    <exclude>org.apache.hive:*</exclude>
+                    <exclude>org.apache.kudu:*</exclude>
+                    <exclude>org.apache.parquet:*</exclude>
+                    <exclude>org.apache.avro:*</exclude>
+                    <exclude>org.apache.orc:*</exclude>
+                    <exclude>org.jdom:jdom</exclude>
+                    <exclude>org.bouncycastle:bcprov-jdk15on:*</exclude>
+                    <exclude>org.bouncycastle:bcprov-jdk15to18:*</exclude>
+                    <exclude>org.bouncycastle:bcprov-jdk15on:*</exclude>
+                    <exclude>org.bouncycastle:bcpkix-jdk15to18:*</exclude>
+                  </excludes>
+                  <includes>
+                    <!-- ranger-plugins-audit depends on jetty-client, which in turn pulls in jetty-http and jetty-io. -->
+                    <include>org.eclipse.jetty:jetty-client</include>
+                    <include>org.eclipse.jetty:jetty-http</include>
+                    <include>org.eclipse.jetty:jetty-io</include>
+                    <!-- jetty-security is needed by jetty-servlet. -->
+                    <include>org.eclipse.jetty:jetty-security</include>
+                    <!-- jetty-servlet is required by hive-standalone-metastore after HIVE-26071. -->
+                    ￼                    <include>org.eclipse.jetty:jetty-servlet</include>
+                    <!-- jetty-server is required when HiveMetaStoreClient is instantiated after HIVE-21456. -->
+                    <include>org.eclipse.jetty:jetty-server</include>
+                    <!-- hadoop-yarn-common depends on some Jetty utilities. -->
+                    <include>org.eclipse.jetty:jetty-util</include>
+                    <include>org.eclipse.jetty:jetty-util-ajax</include>
+                    <!-- Include the allowed versions specifically -->
+                    <include>org.apache.hadoop:*:${hadoop.version}</include>
+                    <include>org.apache.hadoop:*:${ozone.version}</include>
+                    <include>org.apache.hbase:*:${hbase.version}</include>
+                    <include>org.apache.hive:*:${hive.version}</include>
+                    <include>org.apache.hive:hive-storage-api:${hive.storage.api.version}</include>
+                    <include>org.apache.kudu:*:${kudu.version}</include>
+                    <include>org.apache.avro:*:${avro.version}</include>
+                    <include>org.apache.parquet:*:${parquet.version}</include>
+                    <include>org.apache.orc:*:${orc.version}</include>
+                    <include>org.apache.ozone:*:${ozone.version}</include>
+                  </includes>
+                </bannedDependencies>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
     <pluginManagement>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.impala</groupId>
     <artifactId>impala-parent</artifactId>
-    <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+    <version>4.4.1.3.3.6.1-SNAPSHOT</version>
     <relativePath>../java/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -122,6 +122,18 @@ under the License.
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-metastore</artifactId>
       <version>${hive.version}</version>
+      <exclusions>
+        <exclusion>
+          <!-- Exclude ant and jetty dependencies -->
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- Exclude leveldbjni-all, log4j, jetty dependencies -->
+          <groupId>org.apache.hive.shims</groupId>
+          <artifactId>hive-shims-0.23</artifactId>
+        </exclusion>
+      </exclusions>
    </dependency>
 
     <dependency>
@@ -571,6 +583,11 @@ under the License.
           <groupId>org.apache.hadoop</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <!-- IMPALA-11673: spring-jcl conflicts with commons-logging -->
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-jcl</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -599,6 +616,20 @@ under the License.
         <exclusion>
           <groupId>org.apache.hive</groupId>
           <artifactId>hive-shims</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- Exclude ant and jetty dependencies -->
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-service</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- Exclude ant and jetty dependencies -->
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.ant</groupId>
+          <artifactId>ant</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>
@@ -641,6 +672,11 @@ under the License.
         <exclusion>
           <groupId>com.cloudera</groupId>
           <artifactId>*</artifactId>
+        </exclusion>
+        <!-- IMPALA-11673: spring-jcl conflicts with commons-logging -->
+        <exclusion>
+          <groupId>org.springframework</groupId>
+          <artifactId>spring-jcl</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/fe/src/main/java/org/apache/impala/analysis/Analyzer.java
+++ b/fe/src/main/java/org/apache/impala/analysis/Analyzer.java
@@ -1792,7 +1792,7 @@ public class Analyzer {
 
     Preconditions.checkState(collTblRef.getCollectionExpr() instanceof SlotRef);
     SlotDescriptor desc = ((SlotRef) collTblRef.getCollectionExpr()).getDesc();
-    desc.setIsMaterializedRecursively(true);
+    desc.setShouldMaterializeRecursively(true);
 
     try (TupleStackGuard guard = new TupleStackGuard(desc.getItemTupleDesc())) {
       if (slotPath.destType().isArrayType()) {

--- a/fe/src/main/java/org/apache/impala/analysis/ExprSubstitutionMap.java
+++ b/fe/src/main/java/org/apache/impala/analysis/ExprSubstitutionMap.java
@@ -245,44 +245,4 @@ public final class ExprSubstitutionMap {
     }
     return true;
   }
-
-  /**
-   * Remove expressions that are not used according to baseTblSMap
-   */
-  public void trim(ExprSubstitutionMap baseTblSMap, Analyzer analyzer) {
-    Preconditions.checkState(size() == baseTblSMap.size());
-    for (int i = size() - 1; i >= 0; --i) {
-      final Expr baseTblExpr = baseTblSMap.getRhs().get(i);
-      List<SlotId> slotIds = new ArrayList<>();
-      baseTblExpr.getIds(null, slotIds);
-      // Struct children are allowed to be non-materialised because the query may only
-      // concern a subset of the fields of the struct. In this case we do not remove the
-      // entry from this 'ExprSubstitutionMap', only if none of the children are
-      // materialised.
-      if (!baseTblExpr.getType().isStructType()) {
-        for (SlotId id: slotIds) {
-          if (!analyzer.getSlotDesc(id).isMaterialized()) {
-            Expr removed = lhs_.remove(i);
-            substitutions_.remove(removed);
-            rhs_.remove(i);
-            break;
-          }
-        }
-      } else { // If it is a struct, remove iff none of the children are materialised.
-        boolean foundMaterialized = false;
-        for (SlotId id: slotIds) {
-          if (analyzer.getSlotDesc(id).isMaterialized()) {
-            foundMaterialized = true;
-            break;
-          }
-        }
-        if (!foundMaterialized) {
-          Expr removed = lhs_.remove(i);
-          substitutions_.remove(removed);
-          rhs_.remove(i);
-        }
-      }
-    }
-    verify();
-  }
 }

--- a/fe/src/main/java/org/apache/impala/analysis/SortInfo.java
+++ b/fe/src/main/java/org/apache/impala/analysis/SortInfo.java
@@ -276,7 +276,7 @@ public class SortInfo {
           Preconditions.checkNotNull(null);
         }
       } else if (dstType.isCollectionType()) {
-        dstSlotDesc.setIsMaterializedRecursively(true);
+        dstSlotDesc.setShouldMaterializeRecursively(true);
       }
       outputSmap_.put(srcExpr.clone(), dstExpr);
       materializedExprs_.add(srcExpr);

--- a/fe/src/main/java/org/apache/impala/analysis/TupleDescriptor.java
+++ b/fe/src/main/java/org/apache/impala/analysis/TupleDescriptor.java
@@ -441,7 +441,7 @@ public class TupleDescriptor {
           nullIndicatorByte = nullIndicators.first;
           nullIndicatorBit = nullIndicators.second;
         }
-        if (d.getType().isCollectionType() && d.isMaterializedRecursively()) {
+        if (d.getType().isCollectionType() && d.shouldMaterializeRecursively()) {
           d.getItemTupleDesc().computeMemLayout();
         }
       }

--- a/fe/src/main/java/org/apache/impala/extdatasource/jdbc/dao/DatabaseAccessor.java
+++ b/fe/src/main/java/org/apache/impala/extdatasource/jdbc/dao/DatabaseAccessor.java
@@ -24,7 +24,7 @@ import org.apache.impala.extdatasource.jdbc.exception.JdbcDatabaseAccessExceptio
 
 public interface DatabaseAccessor {
 
-  int getTotalNumberOfRecords(Configuration conf)
+  long getTotalNumberOfRecords(Configuration conf)
       throws JdbcDatabaseAccessException;
 
   JdbcRecordIterator getRecordIterator(Configuration conf, int limit, int offset)

--- a/fe/src/main/java/org/apache/impala/extdatasource/jdbc/dao/GenericJdbcDatabaseAccessor.java
+++ b/fe/src/main/java/org/apache/impala/extdatasource/jdbc/dao/GenericJdbcDatabaseAccessor.java
@@ -71,7 +71,7 @@ public class GenericJdbcDatabaseAccessor implements DatabaseAccessor {
       new DataSourceObjectCache();
 
   @Override
-  public int getTotalNumberOfRecords(Configuration conf)
+  public long getTotalNumberOfRecords(Configuration conf)
       throws JdbcDatabaseAccessException {
     Connection conn = null;
     PreparedStatement ps = null;
@@ -89,7 +89,7 @@ public class GenericJdbcDatabaseAccessor implements DatabaseAccessor {
       ps = conn.prepareStatement(countQuery);
       rs = ps.executeQuery();
       if (rs.next()) {
-        return rs.getInt(1);
+        return rs.getLong(1);
       } else {
         LOG.warn("The count query '{}' did not return any results.", countQuery);
         throw new JdbcDatabaseAccessException(

--- a/fe/src/main/java/org/apache/impala/planner/RuntimeFilterGenerator.java
+++ b/fe/src/main/java/org/apache/impala/planner/RuntimeFilterGenerator.java
@@ -1418,16 +1418,19 @@ public final class RuntimeFilterGenerator {
       targetExpr.collect(SlotRef.class, exprSlots);
       List<SlotId> sids = filter.getTargetSlots().get(targetTid);
       for (SlotRef slotRef: exprSlots) {
+        boolean matched = false;
         for (SlotId sid: sids) {
           if (analyzer.hasValueTransfer(slotRef.getSlotId(), sid)) {
             SlotRef newSlotRef = new SlotRef(analyzer.getSlotDesc(sid));
             newSlotRef.analyzeNoThrow(analyzer);
             smap.put(slotRef, newSlotRef);
+            matched = true;
             break;
           }
         }
+        Preconditions.checkState(matched,
+            "No SlotId found for RuntimeFilter %s SlotRef %s", filter, slotRef);
       }
-      Preconditions.checkState(exprSlots.size() == smap.size());
       try {
         targetExpr = targetExpr.substitute(smap, analyzer, false);
       } catch (Exception e) {

--- a/fe/src/main/java/org/apache/impala/planner/SingleNodePlanner.java
+++ b/fe/src/main/java/org/apache/impala/planner/SingleNodePlanner.java
@@ -1254,12 +1254,8 @@ public class SingleNodePlanner {
     // of the inline view's plan root. This ensures that all downstream exprs referencing
     // the inline view are replaced with exprs referencing the physical output of the
     // inline view's plan.
-    ExprSubstitutionMap outputSmap = inlineViewRef.getSmap();
-    if (outputSmap != null && !inlineViewRef.isTableMaskingView()) {
-      outputSmap.trim(inlineViewRef.getBaseTblSmap(), analyzer);
-    }
-    outputSmap = ExprSubstitutionMap.compose(
-        outputSmap, rootNode.getOutputSmap(), analyzer);
+    ExprSubstitutionMap outputSmap = ExprSubstitutionMap.compose(
+        inlineViewRef.getSmap(), rootNode.getOutputSmap(), analyzer);
     if (analyzer.isOuterJoined(inlineViewRef.getId())) {
       // Exprs against non-matched rows of an outer join should always return NULL.
       // Make the rhs exprs of the output smap nullable, if necessary. This expr wrapping

--- a/fe/src/test/java/org/apache/impala/planner/PlannerTest.java
+++ b/fe/src/test/java/org/apache/impala/planner/PlannerTest.java
@@ -1580,4 +1580,13 @@ public class PlannerTest extends PlannerTestBase {
         "location '/'");
     runPlannerTestFile("many-expression", "test_many_expressions");
   }
+
+  /**
+   * Test that runtime filters with the same expression repeated multiple times are
+   * planned successfully (IMPALA-13270).
+   */
+  @Test
+  public void testRuntimeFilterRepeatedExpr() {
+    runPlannerTestFile("runtime-filter-repeated-expr", "functional");
+  }
 }

--- a/java/TableFlattener/pom.xml
+++ b/java/TableFlattener/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.impala</groupId>
     <artifactId>impala-parent</artifactId>
-    <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+    <version>4.4.1.3.3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>nested-table-flattener</artifactId>

--- a/java/calcite-planner/pom.xml
+++ b/java/calcite-planner/pom.xml
@@ -22,12 +22,12 @@ under the License.
   <parent>
     <groupId>org.apache.impala</groupId>
     <artifactId>impala-parent</artifactId>
-    <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+    <version>4.4.1.3.3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>calcite-planner</artifactId>
-  <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+  <version>4.4.1.3.3.6.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>calcite-planner</name>
@@ -36,7 +36,7 @@ under the License.
     <dependency>
       <groupId>org.apache.impala</groupId>
       <artifactId>impala-frontend</artifactId>
-      <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+      <version>4.4.1.3.3.6.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.calcite</groupId>

--- a/java/datagenerator/pom.xml
+++ b/java/datagenerator/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.impala</groupId>
     <artifactId>impala-parent</artifactId>
-    <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+    <version>4.4.1.3.3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/executor-deps/pom.xml
+++ b/java/executor-deps/pom.xml
@@ -34,7 +34,7 @@ under the License.
   <parent>
     <groupId>org.apache.impala</groupId>
     <artifactId>impala-parent</artifactId>
-    <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+    <version>4.4.1.3.3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.impala</groupId>

--- a/java/ext-data-source/api/pom.xml
+++ b/java/ext-data-source/api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.impala</groupId>
     <artifactId>impala-data-source</artifactId>
-    <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+    <version>4.4.1.3.3.6.1-SNAPSHOT</version>
   </parent>
   <artifactId>impala-data-source-api</artifactId>
   <name>Apache Impala External Data Source API</name>

--- a/java/ext-data-source/jdbc/pom.xml
+++ b/java/ext-data-source/jdbc/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.impala</groupId>
     <artifactId>impala-data-source</artifactId>
-    <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+    <version>4.4.1.3.3.6.1-SNAPSHOT</version>
   </parent>
   <artifactId>impala-data-source-jdbc</artifactId>
   <name>Apache Impala External Data Source JDBC Library</name>

--- a/java/ext-data-source/pom.xml
+++ b/java/ext-data-source/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.impala</groupId>
     <artifactId>impala-parent</artifactId>
-    <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+    <version>4.4.1.3.3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>impala-data-source</artifactId>

--- a/java/ext-data-source/sample/pom.xml
+++ b/java/ext-data-source/sample/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.impala</groupId>
     <artifactId>impala-data-source</artifactId>
-    <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+    <version>4.4.1.3.3.6.1-SNAPSHOT</version>
   </parent>
   <artifactId>impala-data-source-sample</artifactId>
   <name>Apache Impala External Data Source Sample</name>

--- a/java/ext-data-source/test/pom.xml
+++ b/java/ext-data-source/test/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.apache.impala</groupId>
     <artifactId>impala-data-source</artifactId>
-    <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+    <version>4.4.1.3.3.6.1-SNAPSHOT</version>
   </parent>
   <artifactId>impala-data-source-test</artifactId>
   <name>Apache Impala External Data Source Test Library</name>

--- a/java/external-frontend/pom.xml
+++ b/java/external-frontend/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.impala</groupId>
     <artifactId>impala-parent</artifactId>
-    <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+    <version>4.4.1.3.3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
@@ -36,7 +36,7 @@ under the License.
     <dependency>
       <groupId>org.apache.impala</groupId>
       <artifactId>impala-frontend</artifactId>
-      <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+      <version>4.4.1.3.3.6.1-SNAPSHOT</version>
     </dependency>
   </dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@ under the License.
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.impala</groupId>
   <artifactId>impala-parent</artifactId>
-  <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+  <version>4.4.1.3.3.6.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Impala Parent POM</name>
   <!--

--- a/java/query-event-hook-api/pom.xml
+++ b/java/query-event-hook-api/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.impala</groupId>
     <artifactId>impala-parent</artifactId>
-    <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+    <version>4.4.1.3.3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>query-event-hook-api</artifactId>

--- a/java/shaded-deps/hive-exec/pom.xml
+++ b/java/shaded-deps/hive-exec/pom.xml
@@ -27,7 +27,7 @@ the same dependencies
   <parent>
     <groupId>org.apache.impala</groupId>
     <artifactId>impala-parent</artifactId>
-    <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+    <version>4.4.1.3.3.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/java/shaded-deps/s3a-aws-sdk/pom.xml
+++ b/java/shaded-deps/s3a-aws-sdk/pom.xml
@@ -25,7 +25,7 @@ though some of them might not be necessary. The exclusions are sorted alphabetic
   <parent>
     <groupId>org.apache.impala</groupId>
     <artifactId>impala-parent</artifactId>
-    <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+    <version>4.4.1.3.3.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/java/test-corrupt-hive-udfs/pom.xml
+++ b/java/test-corrupt-hive-udfs/pom.xml
@@ -23,7 +23,7 @@ under the License.
   <parent>
     <groupId>org.apache.impala</groupId>
     <artifactId>impala-parent</artifactId>
-    <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+    <version>4.4.1.3.3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/test-hive-udfs/pom.xml
+++ b/java/test-hive-udfs/pom.xml
@@ -22,7 +22,7 @@ under the License.
   <parent>
     <groupId>org.apache.impala</groupId>
     <artifactId>impala-parent</artifactId>
-    <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+    <version>4.4.1.3.3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/java/yarn-extras/pom.xml
+++ b/java/yarn-extras/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.impala</groupId>
     <artifactId>impala-parent</artifactId>
-    <version>4.4.0.3.3.6.1-SNAPSHOT</version>
+    <version>4.4.1.3.3.6.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>yarn-extras</artifactId>

--- a/testdata/workloads/functional-planner/queries/PlannerTest/runtime-filter-repeated-expr.test
+++ b/testdata/workloads/functional-planner/queries/PlannerTest/runtime-filter-repeated-expr.test
@@ -1,0 +1,31 @@
+SELECT alt.int_col, alt.string_col
+FROM alltypes alt
+INNER JOIN (
+  SELECT int_col,
+    concat('20',
+      substring(date_string_col, 7, 2), '-',
+      substring(date_string_col, 4, 2), '-',
+      substring(date_string_col, 1, 2), ' 00:00:00') ts
+  FROM alltypesaggnonulls GROUP BY int_col, date_string_col
+) altann ON altann.ts = from_unixtime(alt.id, 'yyyy-MM-dd HH:mm:ss')
+---- PLAN
+PLAN-ROOT SINK
+|
+03:HASH JOIN [INNER JOIN]
+|  hash predicates: concat('20', substring(date_string_col, 7, 2), '-', substring(date_string_col, 4, 2), '-', substring(date_string_col, 1, 2), ' 00:00:00') = from_unixtime(alt.id, 'yyyy-MM-dd HH:mm:ss')
+|  runtime filters: RF000 <- from_unixtime(alt.id, 'yyyy-MM-dd HH:mm:ss')
+|  row-size=36B cardinality=9.08K
+|
+|--00:SCAN HDFS [functional.alltypes alt]
+|     HDFS partitions=24/24 files=24 size=478.45KB
+|     row-size=20B cardinality=6.12K
+|
+02:AGGREGATE [FINALIZE]
+|  group by: int_col, date_string_col
+|  row-size=16B cardinality=9.08K
+|
+01:SCAN HDFS [functional.alltypesaggnonulls]
+   HDFS partitions=10/10 files=10 size=744.82KB
+   runtime filters: RF000 -> concat('20', substring(functional.alltypesaggnonulls.date_string_col, 7, 2), '-', substring(functional.alltypesaggnonulls.date_string_col, 4, 2), '-', substring(functional.alltypesaggnonulls.date_string_col, 1, 2), ' 00:00:00')
+   row-size=16B cardinality=9.08K
+====

--- a/testdata/workloads/functional-query/queries/QueryTest/sort-complex.test
+++ b/testdata/workloads/functional-query/queries/QueryTest/sort-complex.test
@@ -151,6 +151,66 @@ select id, arr_contains_nested_struct from collection_struct_mix order by id;
 INT,STRING
 ====
 ---- QUERY
+# Regression test for # IMPALA-13272
+select
+  row_no
+from (
+  select
+    arr.small,
+    row_number() over (order by arr.inner_struct1.str) as row_no
+  from collection_struct_mix t, t.arr_contains_nested_struct arr
+) res;
+---- RESULTS
+1
+2
+3
+4
+5
+6
+---- TYPES
+BIGINT
+====
+---- QUERY
+# Regression test for # IMPALA-13272
+select
+  row_no, str
+from (
+  select
+    arr.small,
+    arr.inner_struct1.str str,
+    row_number() over (order by arr.inner_struct1.str) as row_no
+  from collection_struct_mix t, t.arr_contains_nested_struct arr
+) res;
+---- RESULTS
+1,''
+2,'a few soju distilleries'
+3,'NULL'
+4,'NULL'
+5,'NULL'
+6,'NULL'
+---- TYPES
+BIGINT,STRING
+====
+---- QUERY
+# Regression test for # IMPALA-13272
+select
+  row_no, str, small
+from (
+  select
+    arr.small,
+    arr.inner_struct2.str str,
+    row_number() over (order by arr.inner_struct2.str) as row_no
+  from collection_struct_mix t, t.arr_contains_nested_struct arr
+) res limit 4;
+---- RESULTS
+1,'four spaceship captains',2
+2,'lots of soju distilleries',105
+3,'more spaceship captains',20
+4,'very few distilleries',104
+---- TYPES
+BIGINT,STRING, SMALLINT
+====
+---- QUERY
 # Sorting is not supported yet for collections within structs: IMPALA-12160. Test with a
 # struct that contains an array.
 select id, struct_contains_arr from collection_struct_mix order by id


### PR DESCRIPTION
ODP-4409 Backport missing commits from Impala 4.4.1 to ODP-main
ODP-4409 Revert Maven enforcer plugin to enforce banned dependencies
ODP-4409 Fix Impala to exclude banned dependencies
ODP-4409 Update Impala version to 4.4.1.3.3.6.1-SNAPSHOT