### PR TITLE
ODP-6306: Revert "OSV-11066: Bump sqlparse due to CVE (#43)"

### DIFF
--- a/infra/python/deps/requirements.txt
+++ b/infra/python/deps/requirements.txt
@@ -60,7 +60,7 @@ requests == 2.21.0
 sasl == 0.2.1
 sh == 1.11
 six == 1.14.0
-sqlparse == 0.5.4
+sqlparse == 0.3.1
 texttable == 0.8.3
 virtualenv == 16.7.10
 avro==1.10.2

--- a/shell/packaging/requirements.txt
+++ b/shell/packaging/requirements.txt
@@ -4,6 +4,6 @@ kerberos==1.3.1
 prettytable==0.7.2
 setuptools>=36.8.0
 six==1.14.0
-sqlparse==0.5.4
+sqlparse==0.3.1
 thrift==0.16.0
 thrift_sasl==0.4.3


### PR DESCRIPTION
This patch has been tested locally.
