### PR TITLE
ODP-6342 : Bump Netty version to 4.1.132.Final

### DIFF
--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -367,7 +367,7 @@ under the License.
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- OSV-11063 -  kudu-client pulls in netty-handler 4.1.94.Final; override to 4.1.130.Final. -->
+    <!-- OSV-11063 -  kudu-client pulls in netty-handler 4.1.94.Final; override to 4.1.132.Final. -->
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-handler</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -88,8 +88,8 @@ under the License.
     <dnsjava.version>3.6.0</dnsjava.version>
     <aircompressor.version>2.0.3</aircompressor.version>
     <!-- OSV-11063 netty-handler and
-         related modules pulled in by kudu-client. 4.1.130.Final fixes all known Netty CVEs. -->
-    <netty.version>4.1.130.Final</netty.version>
+         related modules pulled in by kudu-client. 4.1.132.Final fixes all known Netty CVEs. -->
+    <netty.version>4.1.132.Final</netty.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
This patch was tested locally.