### PR TITLE
OSV-19108 - CVE - Increasing netty version to 4.1.133.Final (netty-bom) to fix the Impala netty CVEs

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -89,7 +89,7 @@ under the License.
     <aircompressor.version>2.0.3</aircompressor.version>
     <!-- OSV-11063 netty-handler and
          related modules pulled in by kudu-client. 4.1.132.Final fixes all known Netty CVEs. -->
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.133.Final</netty.version>
   </properties>
 
   <repositories>
@@ -452,7 +452,15 @@ under the License.
       </dependency>
 
       <!-- Override Netty versions (transitive from kudu-client) to address multiple CVEs.
-           OSV-11063 . Fixed in 4.1.129.Final. -->
+           OSV-11063 . Fixed in 4.1.129.Final. netty-bom aligns every io.netty:*
+           module (incl. netty-codec-dns/mqtt/redis/common) to ${netty.version}. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>


### PR DESCRIPTION
- Tickets : OSV-19209, OSV-19207, OSV-19142, OSV-19137, OSV-19117, OSV-19113, OSV-19112, OSV-19111, OSV-19110, OSV-19109, OSV-19108