### PR TITLE
OSV-19139 - CVE - Increasing commons-configuration2 version to 2.15.0 to fix the Impala commons-configuration2 CVEs

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -82,7 +82,7 @@ under the License.
     <log4j2.version>${env.IMPALA_LOG4J2_VERSION}</log4j2.version>
     <aws_java_sdk_bundle.version>${env.IMPALA_AWS_JAVA_SDK_BUNDLE_VERSION}</aws_java_sdk_bundle.version>
     <protobuf-java.version>${env.IMPALA_PROTOBUF_JAVA_VERSION}</protobuf-java.version>
-    <commons-configuration2.version>2.10.1</commons-configuration2.version>
+    <commons-configuration2.version>2.15.0</commons-configuration2.version>
     <jdom2.version>2.0.6.1</jdom2.version>
     <commons-lang3.version>3.18.0</commons-lang3.version>
     <dnsjava.version>3.6.0</dnsjava.version>


### PR DESCRIPTION
- Tickets : OSV-19139