### PR TITLE
OSV-19206 - CVE - Pinning okio to 1.17.6 to fix the Impala okio CVEs

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -296,6 +296,12 @@ under the License.
       </dependency>
 
       <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>1.17.6</version>
+      </dependency>
+
+      <dependency>
         <groupId>net.minidev</groupId>
         <artifactId>json-smart</artifactId>
         <version>${json-smart.version}</version>


### PR DESCRIPTION
- Tickets : OSV-19206