### PR TITLE
OSV-22321 - CVE - Bumped-up commons-lang3 to 3.18.0 to address CVE-2025-48924

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -85,6 +85,7 @@ under the License.
     <protobuf-java.version>${env.IMPALA_PROTOBUF_JAVA_VERSION}</protobuf-java.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
     <netty.version>4.1.133.Final</netty.version>
+        <commons-lang3.version>3.18.0</commons-lang3.version>
   </properties>
 
   <repositories>
@@ -284,6 +285,12 @@ under the License.
 
   <dependencyManagement>
     <dependencies>
+<dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.18.0</version>
+      </dependency>
+
 
       <dependency>
         <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
- Component: impala (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: commons-lang3 → 3.18.0
- Tickets: OSV-22321
- Files: java/pom.xml, java/pom.xml