### PR TITLE
OSV-22331 - CVE - Bumped-up commons-compress to 1.26.0 to address CVE-2023-42503/CVE-2024-25710/CVE-2024-26308

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -86,6 +86,7 @@ under the License.
     <commons-configuration2.version>2.15.0</commons-configuration2.version>
     <netty.version>4.1.133.Final</netty.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
+        <commons-compress.version>1.26.0</commons-compress.version>
   </properties>
 
   <repositories>
@@ -285,6 +286,12 @@ under the License.
 
   <dependencyManagement>
     <dependencies>
+<dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-compress</artifactId>
+        <version>1.26.0</version>
+      </dependency>
+
 <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>


### PR DESCRIPTION
- Component: impala (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: commons-compress → 1.26.0
- Tickets: OSV-22331, OSV-22332, OSV-22333
- Files: java/pom.xml, java/pom.xml