### PR TITLE
OSV-22244 - CVE - Bumped-up Netty to 4.1.133.Final to address CVE-2025-58056/CVE-2025-58057/CVE-2025-67735/CVE-2026-33870/CVE-2026-41417/CVE-2026-42580/CVE-2026-42581/CVE-2026-42583/CVE-2026-42584/CVE-2026-42585/CVE-2026-42587

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -84,7 +84,7 @@ under the License.
     <aws_java_sdk_bundle.version>${env.IMPALA_AWS_JAVA_SDK_BUNDLE_VERSION}</aws_java_sdk_bundle.version>
     <protobuf-java.version>${env.IMPALA_PROTOBUF_JAVA_VERSION}</protobuf-java.version>
     <commons-configuration2.version>2.10.1</commons-configuration2.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.133.Final</netty.version>
   </properties>
 
   <repositories>
@@ -428,7 +428,15 @@ under the License.
 
       <!-- Override Netty versions (transitive from kudu-client) to address multiple CVEs.
            OSV-11063 . Fixed in 4.1.129.Final. -->
+      
       <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+<dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
         <version>${netty.version}</version>


### PR DESCRIPTION
- Component: impala (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: Netty → 4.1.133.Final
- Tickets: OSV-22244, OSV-22245, OSV-22246, OSV-22247, OSV-22248, OSV-22249, OSV-22250, OSV-22251, OSV-22252, OSV-22318, OSV-22319
- Files: java/pom.xml