### PR TITLE
OSV-22301 - CVE - Bumped-up okio to 3.4.0 to address CVE-2023-3635

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -509,7 +509,17 @@ under the License.
         <artifactId>netty-codec-compression</artifactId>
         <version>${netty.version}</version>
       </dependency>
-    </dependencies>
+    <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>3.4.0</version>
+      </dependency>
+    <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio-jvm</artifactId>
+        <version>3.4.0</version>
+      </dependency>
+  </dependencies>
   </dependencyManagement>
 
   <modules>


### PR DESCRIPTION
- Component: impala (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: okio → 3.4.0
- Tickets: OSV-22301
- Files: java/pom.xml, java/pom.xml