### PR TITLE
OSV-22274 - CVE - Bumped-up OpenTelemetry to 1.62.0 to address CVE-2026-45292

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -288,6 +288,12 @@ under the License.
   <dependencyManagement>
     <dependencies>
 <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-api</artifactId>
+        <version>1.62.0</version>
+      </dependency>
+
+<dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-bom</artifactId>
         <version>${jetty.version}</version>


### PR DESCRIPTION
- Component: impala (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: OpenTelemetry → 1.62.0
- Tickets: OSV-22274
- Files: java/pom.xml