### PR TITLE
OSV-22359 - CVE - Bumped-up grpc-netty-shaded to 1.75.0 to address CVE-2025-55163

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -288,6 +288,12 @@ under the License.
   <dependencyManagement>
     <dependencies>
 <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-netty-shaded</artifactId>
+        <version>1.75.0</version>
+      </dependency>
+
+<dependency>
         <groupId>io.opentelemetry</groupId>
         <artifactId>opentelemetry-api</artifactId>
         <version>1.62.0</version>


### PR DESCRIPTION
- Component: impala (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: grpc-netty-shaded → 1.75.0
- Tickets: OSV-22359
- Files: java/pom.xml