### PR TITLE
OSV-22369 - CVE - Bumped-up logback to 1.5.25 to address CVE-2026-1225

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -284,6 +284,20 @@ under the License.
 
   <dependencyManagement>
     <dependencies>
+
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>1.5.25</version>
+      </dependency>
+
+
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>1.5.25</version>
+      </dependency>
+
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>


### PR DESCRIPTION
- Component: impala (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: logback → 1.5.25
- Tickets: OSV-22369
- Files: java/pom.xml, java/pom.xml