### PR TITLE
OSV-22375 - CVE - Bumped-up sqlparse to 0.5.4 to address CVE-2023-30608/CVE-2024-4340/GHSA-27jp-wm6q-gp25

### DIFF
--- a/infra/python/deps/requirements.txt
+++ b/infra/python/deps/requirements.txt
@@ -60,7 +60,7 @@ requests == 2.21.0
 sasl == 0.2.1
 sh == 1.11
 six == 1.14.0
-sqlparse == 0.3.1
+sqlparse == 0.5.4
 texttable == 0.8.3
 virtualenv == 16.7.10
 avro==1.10.2


### PR DESCRIPTION
- Component: impala (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: sqlparse → 0.5.4
- Tickets: OSV-22375, OSV-22376, OSV-22377
- Files: infra/python/deps/requirements.txt