### PR TITLE
ODP-7418: Revert "OSV-22375 - CVE - Bumped-up sqlparse to 0.5.4 to address CVE-023-230608/CVE-2024-4340/GHSA-27jp-wm6q-gp25 (#83)"

### DIFF
--- a/infra/python/deps/requirements.txt
+++ b/infra/python/deps/requirements.txt
@@ -60,7 +60,7 @@ requests == 2.21.0
 sasl == 0.2.1
 sh == 1.11
 six == 1.14.0
-sqlparse == 0.5.4
+sqlparse == 0.3.1
 texttable == 0.8.3
 virtualenv == 16.7.10
 avro==1.10.2


### PR DESCRIPTION
…2023-30608/CVE-2024-4340/GHSA-27jp-wm6q-gp25 (#83)"

This reverts commit 144a643be6291b1bb82353c3fa75d1a97a78c7a0.