### PR TITLE
ODP-7418: Pre-install pbr 3.1.1 before main deps to fix pywebhdfs build

### DIFF
--- a/infra/python/deps/setuptools-requirements.txt
+++ b/infra/python/deps/setuptools-requirements.txt
@@ -1,3 +1,4 @@
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -19,3 +20,5 @@
 setuptools == 44.1.1
   wheel == 0.35.1
 setuptools-scm == 5.0.2
+# Pre-install pbr so pywebhdfs setup_requires doesn't fetch pbr 7.x via EasyInstall
+pbr == 3.1.1


### PR DESCRIPTION
pywebhdfs setup.py has setup_requires=['pbr'] with no version pin. setuptools EasyInstall resolves this independently from pip --find-links, fetching pbr 7.1.0 which requires tomli (not available on Python 3.7). Installing pbr 3.1.1 in the setuptools step ensures it's in sys.path before pywebhdfs is processed, so EasyInstall finds it satisfied.